### PR TITLE
Reduce 3DS MTU

### DIFF
--- a/include/enet/protocol.h
+++ b/include/enet/protocol.h
@@ -1,4 +1,4 @@
-/** 
+/**
  @file  protocol.h
  @brief ENet protocol
 */
@@ -10,7 +10,7 @@
 enum
 {
    ENET_PROTOCOL_MINIMUM_MTU             = 576,
-#ifdef __WIIU__
+#if defined(__WIIU__) || defined(__3DS__)
    ENET_PROTOCOL_MAXIMUM_MTU             = 1400,
 #else
    ENET_PROTOCOL_MAXIMUM_MTU             = 4096,

--- a/unix.c
+++ b/unix.c
@@ -469,7 +469,11 @@ enet_socket_get_option (ENetSocket socket, ENetSocketOption option, int * value)
     {
         case ENET_SOCKOPT_ERROR:
             len = sizeof (int);
+#ifndef __3DS__ //getsockopt is unreliable on 3DS
             result = getsockopt (socket, SOL_SOCKET, SO_ERROR, value, & len);
+#else
+            result = 0;
+#endif
             break;
 
         case ENET_SOCKOPT_TTL:


### PR DESCRIPTION
- Drop the 3DS MTU to 1400 (default value according to https://www.3dbrew.org/wiki/Config_Savegame)
- Prevent using `getsockopt` on the 3DS (`SO_ERROR` is unreliable)